### PR TITLE
feat: add official Qwen Max service tip and improved i18n

### DIFF
--- a/public/locales/en/commons.json
+++ b/public/locales/en/commons.json
@@ -203,6 +203,16 @@
   "uploads-info": {
     "selected": "Selected"
   },
+  "qwen-callout": {
+    "title": "Official Qwen Max Service",
+    "badge": "Free",
+    "button": "Get token",
+    "tooltip": {
+      "prefix": "How to import into SkidHomework? Visit",
+      "link": "Console -> Token Management",
+      "suffix": "-> Chat quick import for SkidHomework."
+    }
+  },
   "settings-page": {
     "heading": "SkidHomework Settings",
     "back": "Back",
@@ -372,7 +382,8 @@
       },
       "ui": {
         "title": "UI",
-        "show-donate-btn": "Show donate button"
+        "show-donate-btn": "Show donate button",
+        "show-qwen-hint": "Show Qwen Max service tip"
       }
     }
   },
@@ -416,6 +427,43 @@
     "footer": {
       "notice": "Licensed under GPLv3, created by cubewhy.",
       "source": "Source Code"
+    }
+  },
+  "import-settings-page": {
+    "error": {
+      "title": "Error",
+      "parse-failed": "Failed to parse configuration. The link might be broken.",
+      "home": "Return Home"
+    },
+    "loading": {
+      "parsing": "Parsing configuration..."
+    },
+    "success": {
+      "title": "You're all set!",
+      "description": "The AI model <strong>{{name}}</strong> has been successfully imported.",
+      "buttons": {
+        "settings": "Settings",
+        "undo": "Undo",
+        "home": "Let's Skid"
+      }
+    },
+    "confirm": {
+      "title": "Import AI Model",
+      "description": "Do you want to add this configuration to your settings?",
+      "fields": {
+        "name": "Name:",
+        "provider": "Provider:",
+        "model": "Model Name:",
+        "base": "Base URL:"
+      },
+      "alert": {
+        "title": "Security Check",
+        "description": "Only import configurations from sources you trust. Otherwise it may cause a privacy leak. Use at your own risk."
+      },
+      "buttons": {
+        "cancel": "Cancel",
+        "confirm": "Yes, Import"
+      }
     }
   },
   "solution-viewer": {

--- a/public/locales/zh/commons.json
+++ b/public/locales/zh/commons.json
@@ -203,6 +203,16 @@
   "uploads-info": {
     "selected": "已选择"
   },
+  "qwen-callout": {
+    "title": "官方 Qwen Max 服务",
+    "badge": "免费",
+    "button": "点击获取",
+    "tooltip": {
+      "prefix": "如何导入到 SkidHomework？你可以前往",
+      "link": "控制台 -> 令牌管理",
+      "suffix": "-> 聊天 快捷导入 SkidHomework。"
+    }
+  },
   "settings-page": {
     "heading": "SkidHomework 设置",
     "back": "返回",
@@ -372,7 +382,8 @@
       },
       "ui": {
         "title": "界面",
-        "show-donate-btn": "显示捐赠按钮"
+        "show-donate-btn": "显示捐赠按钮",
+        "show-qwen-hint": "显示 Qwen Max 服务提示"
       }
     }
   },
@@ -416,6 +427,43 @@
     "footer": {
       "notice": "基于 GPLv3 许可，由 cubewhy 创建。",
       "source": "源代码"
+    }
+  },
+  "import-settings-page": {
+    "error": {
+      "title": "错误",
+      "parse-failed": "无法解析配置，链接可能已损坏。",
+      "home": "返回首页"
+    },
+    "loading": {
+      "parsing": "正在解析配置..."
+    },
+    "success": {
+      "title": "全部就绪！",
+      "description": "AI 模型 <strong>{{name}}</strong> 已成功导入。",
+      "buttons": {
+        "settings": "设置",
+        "undo": "撤销",
+        "home": "返回首页"
+      }
+    },
+    "confirm": {
+      "title": "导入 AI 模型",
+      "description": "要将此配置添加到你的设置中吗？",
+      "fields": {
+        "name": "名称：",
+        "provider": "提供商：",
+        "model": "模型名称：",
+        "base": "基础 URL："
+      },
+      "alert": {
+        "title": "安全提醒",
+        "description": "仅从可信来源导入配置，否则可能导致隐私泄露，请自行承担风险。"
+      },
+      "buttons": {
+        "cancel": "取消",
+        "confirm": "确认导入"
+      }
     }
   },
   "solution-viewer": {

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -14,6 +14,13 @@ export default function Providers({
   children: React.ReactNode;
 }) {
   const language = useSettingsStore((state) => state.language);
+  const initializeLanguage = useSettingsStore(
+    (state) => state.initializeLanguage,
+  );
+
+  useEffect(() => {
+    initializeLanguage();
+  }, [initializeLanguage]);
 
   useEffect(() => {
     if (language && i18n.language !== language) {

--- a/src/components/InfoTooltip.tsx
+++ b/src/components/InfoTooltip.tsx
@@ -1,0 +1,80 @@
+import { useId, useRef, useState, type ReactNode } from "react";
+import { CircleHelp } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface InfoTooltipProps {
+  content: ReactNode;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export function InfoTooltip({
+  content,
+  className,
+  ariaLabel,
+}: InfoTooltipProps) {
+  const [open, setOpen] = useState(false);
+  const tooltipId = useId();
+  const closeTimeout = useRef<NodeJS.Timeout | null>(null);
+
+  const clearCloseTimeout = () => {
+    if (closeTimeout.current) {
+      clearTimeout(closeTimeout.current);
+      closeTimeout.current = null;
+    }
+  };
+
+  const openTooltip = () => {
+    clearCloseTimeout();
+    setOpen(true);
+  };
+
+  const scheduleClose = () => {
+    clearCloseTimeout();
+    closeTimeout.current = setTimeout(() => setOpen(false), 120);
+  };
+
+  const handleBlur = (event: React.FocusEvent<HTMLSpanElement>) => {
+    if (
+      event.relatedTarget &&
+      event.currentTarget.contains(event.relatedTarget as Node)
+    ) {
+      return;
+    }
+    setOpen(false);
+  };
+
+  return (
+    <span
+      className={cn("relative inline-flex", className)}
+      onMouseEnter={openTooltip}
+      onMouseLeave={scheduleClose}
+      onFocusCapture={openTooltip}
+      onBlurCapture={handleBlur}
+    >
+      <button
+        type="button"
+        className="inline-flex items-center justify-center rounded-full text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+        aria-label={ariaLabel ?? (typeof content === "string" ? content : undefined)}
+        aria-expanded={open}
+        aria-describedby={tooltipId}
+        onFocus={openTooltip}
+        onBlur={scheduleClose}
+      >
+        <CircleHelp className="h-4 w-4" />
+      </button>
+      <div
+        id={tooltipId}
+        role="tooltip"
+        className={cn(
+          "absolute left-1/2 top-full z-20 w-64 -translate-x-1/2 translate-y-2 rounded-md border border-border bg-popover px-3 py-2 text-left text-xs text-popover-foreground opacity-0 shadow-lg transition-opacity duration-150",
+          open ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0",
+        )}
+        onMouseEnter={openTooltip}
+        onMouseLeave={scheduleClose}
+      >
+        {content}
+      </div>
+    </span>
+  );
+}

--- a/src/components/pages/ImportSettingsPage.tsx
+++ b/src/components/pages/ImportSettingsPage.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { CheckCircle2, AlertCircle } from "lucide-react";
+import { Trans, useTranslation } from "react-i18next";
 
 // UI Components (Adjust import paths based on your project structure)
 import {
@@ -28,10 +29,13 @@ type ImportAIModelModel = {
 
 export default function ImportSettingsPage() {
   const router = useRouter();
+  const { t } = useTranslation("commons", {
+    keyPrefix: "import-settings-page",
+  });
 
   // State
   const [modelJson, setModelJson] = useState<ImportAIModelModel | null>(null);
-  const [error, setError] = useState<string>("");
+  const [errorKey, setErrorKey] = useState<string>("");
   const [isImported, setIsImported] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -63,7 +67,7 @@ export default function ImportSettingsPage() {
       setModelJson(parsedData);
     } catch (err) {
       console.error(err);
-      setError("Failed to parse configuration. The link might be broken.");
+      setErrorKey("error.parse-failed");
     } finally {
       setIsLoading(false);
     }
@@ -105,21 +109,21 @@ export default function ImportSettingsPage() {
   // ------------------------------------------------------------------
 
   // View 1: Error State
-  if (error) {
+  if (errorKey) {
     return (
       <div className="flex min-h-screen items-center justify-center p-4 bg-muted/40">
         <Card className="w-full max-w-md border-destructive/50">
           <CardHeader>
             <CardTitle className="text-destructive flex items-center gap-2">
-              <AlertCircle className="h-5 w-5" /> Error
+              <AlertCircle className="h-5 w-5" /> {t("error.title")}
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <p>{error}</p>
+            <p>{t(errorKey)}</p>
           </CardContent>
           <CardFooter>
             <Button variant="outline" onClick={() => router.push("/")}>
-              Return Home
+              {t("error.home")}
             </Button>
           </CardFooter>
         </Card>
@@ -132,7 +136,7 @@ export default function ImportSettingsPage() {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <p className="text-muted-foreground animate-pulse">
-          Parsing configuration...
+          {t("loading.parsing")}
         </p>
       </div>
     );
@@ -148,11 +152,15 @@ export default function ImportSettingsPage() {
               <CheckCircle2 className="h-8 w-8" />
             </div>
             <h2 className="text-2xl font-semibold tracking-tight">
-              You&apos;re all set!
+              {t("success.title")}
             </h2>
             <p className="text-muted-foreground">
-              The AI model <strong>{modelJson?.name}</strong> has been
-              successfully imported.
+              <Trans
+                t={t}
+                i18nKey="success.description"
+                values={{ name: modelJson?.name ?? "" }}
+                components={{ strong: <strong /> }}
+              />
             </p>
           </CardContent>
           <CardFooter>
@@ -163,18 +171,18 @@ export default function ImportSettingsPage() {
                   variant="secondary"
                   className="flex-1"
                 >
-                  Settings
+                  {t("success.buttons.settings")}
                 </Button>
                 <Button
                   onClick={handleUndo}
                   variant="destructive"
                   className="flex-1"
                 >
-                  Undo
+                  {t("success.buttons.undo")}
                 </Button>
               </div>
               <Button onClick={() => router.push("/")} className="flex-1">
-                Let&apos;s Skid
+                {t("success.buttons.home")}
               </Button>
             </div>
           </CardFooter>
@@ -188,10 +196,8 @@ export default function ImportSettingsPage() {
     <div className="flex min-h-screen items-center justify-center p-4 bg-muted/40">
       <Card className="w-full max-w-md">
         <CardHeader>
-          <CardTitle>Import AI Model</CardTitle>
-          <CardDescription>
-            Do you want to add this configuration to your settings?
-          </CardDescription>
+          <CardTitle>{t("confirm.title")}</CardTitle>
+          <CardDescription>{t("confirm.description")}</CardDescription>
         </CardHeader>
 
         <CardContent>
@@ -199,13 +205,13 @@ export default function ImportSettingsPage() {
             <div className="grid gap-4 rounded-md border p-4 bg-card/50">
               <div className="grid grid-cols-[100px_1fr] items-center gap-1">
                 <span className="text-sm font-medium text-muted-foreground">
-                  Name:
+                  {t("confirm.fields.name")}
                 </span>
                 <span className="font-medium">{modelJson.name}</span>
               </div>
               <div className="grid grid-cols-[100px_1fr] items-center gap-1">
                 <span className="text-sm font-medium text-muted-foreground">
-                  Provider:
+                  {t("confirm.fields.provider")}
                 </span>
                 <span className="font-medium capitalize">
                   {modelJson.provider}
@@ -213,7 +219,7 @@ export default function ImportSettingsPage() {
               </div>
               <div className="grid grid-cols-[100px_1fr] items-center gap-1">
                 <span className="text-sm font-medium text-muted-foreground">
-                  Model Name:
+                  {t("confirm.fields.model")}
                 </span>
                 <span className="text-sm truncate" title={modelJson.model}>
                   {modelJson.model}
@@ -221,7 +227,7 @@ export default function ImportSettingsPage() {
               </div>
               <div className="grid grid-cols-[100px_1fr] items-center gap-1">
                 <span className="text-sm font-medium text-muted-foreground">
-                  Base URL:
+                  {t("confirm.fields.base")}
                 </span>
                 <span className="text-sm truncate" title={modelJson.baseUrl}>
                   {modelJson.baseUrl}
@@ -232,19 +238,18 @@ export default function ImportSettingsPage() {
 
           <Alert className="mt-4" variant="destructive">
             <AlertCircle className="h-4 w-4" />
-            <AlertTitle>Security Check</AlertTitle>
-            <AlertDescription>
-              Only import configurations from sources you trust. Otherwise it
-              will case a pravicy leak. Use your own risk.
-            </AlertDescription>
+            <AlertTitle>{t("confirm.alert.title")}</AlertTitle>
+            <AlertDescription>{t("confirm.alert.description")}</AlertDescription>
           </Alert>
         </CardContent>
 
         <CardFooter className="flex justify-between gap-2">
           <Button variant="outline" onClick={handleCancel}>
-            Cancel
+            {t("confirm.buttons.cancel")}
           </Button>
-          <Button onClick={handleConfirmImport}>Yes, Import</Button>
+          <Button onClick={handleConfirmImport}>
+            {t("confirm.buttons.confirm")}
+          </Button>
         </CardFooter>
       </Card>
     </div>

--- a/src/components/pages/InitPage.tsx
+++ b/src/components/pages/InitPage.tsx
@@ -5,11 +5,13 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
+import { Badge } from "../ui/badge";
 import {
   DEFAULT_GEMINI_BASE_URL,
   DEFAULT_OPENAI_BASE_URL,
   useAiStore,
 } from "@/store/ai-store";
+import { useSettingsStore } from "@/store/settings-store";
 import {
   Accordion,
   AccordionContent,
@@ -18,12 +20,17 @@ import {
 } from "../ui/accordion";
 import { Label } from "../ui/label";
 import { Trans, useTranslation } from "react-i18next";
+import { InfoTooltip } from "../InfoTooltip";
+import { useQwenHintAutoToggle } from "@/hooks/useQwenHintAutoToggle";
+import { QWEN_TOKEN_URL } from "@/lib/qwen";
 
 export default function InitPage() {
   const sources = useAiStore((s) => s.sources);
   const activeSourceId = useAiStore((s) => s.activeSourceId);
   const setActiveSource = useAiStore((s) => s.setActiveSource);
   const updateSource = useAiStore((s) => s.updateSource);
+  const showQwenHint = useSettingsStore((s) => s.showQwenHint);
+  const setShowQwenHint = useSettingsStore((s) => s.setShowQwenHint);
 
   const activeSource = useMemo(
     () => sources.find((source) => source.id === activeSourceId) ?? sources[0],
@@ -43,6 +50,24 @@ export default function InitPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { t } = useTranslation("commons", { keyPrefix: "init-page" });
+  const { t: tCommon } = useTranslation("commons");
+
+  useQwenHintAutoToggle(sources, showQwenHint, setShowQwenHint);
+
+  const qwenTooltipContent = (
+    <span>
+      {tCommon("qwen-callout.tooltip.prefix")}{" "}
+      <a
+        href={QWEN_TOKEN_URL}
+        target="_blank"
+        rel="noreferrer"
+        className="underline underline-offset-2"
+      >
+        {tCommon("qwen-callout.tooltip.link")}
+      </a>
+      {tCommon("qwen-callout.tooltip.suffix")}
+    </span>
+  );
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -185,6 +210,35 @@ export default function InitPage() {
                   {t("form.submit")}
                 </Button>
               </div>
+
+              {showQwenHint && (
+                <motion.div
+                  initial={{ opacity: 0, y: 12 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.3 }}
+                  className="w-full max-w-md rounded-2xl border border-indigo-300/60 bg-white/90 p-4 text-slate-900 shadow-md dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-100"
+                >
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-semibold">
+                      {tCommon("qwen-callout.title")}
+                    </p>
+                    <InfoTooltip
+                      content={qwenTooltipContent}
+                      ariaLabel={tCommon("qwen-callout.title")}
+                    />
+                  </div>
+                  <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <Badge variant="secondary" className="w-fit">
+                      {tCommon("qwen-callout.badge")}
+                    </Badge>
+                    <Button asChild size="sm" className="sm:w-auto">
+                      <a href={QWEN_TOKEN_URL} target="_blank" rel="noreferrer">
+                        {tCommon("qwen-callout.button")}
+                      </a>
+                    </Button>
+                  </div>
+                </motion.div>
+              )}
 
               {/* START: Advanced settings section, collapsible */}
               <Accordion type="single" collapsible className="w-full max-w-md">

--- a/src/hooks/useQwenHintAutoToggle.ts
+++ b/src/hooks/useQwenHintAutoToggle.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react";
+import type { AiSource } from "@/store/ai-store";
+import { SHOULD_SHOW_QWEN_HINT_DEFAULT } from "@/store/settings-store";
+import { QWEN_BASE_URL } from "@/lib/qwen";
+
+export function useQwenHintAutoToggle(
+  sources: AiSource[],
+  showQwenHint: boolean,
+  setShowQwenHint: (show: boolean) => void,
+) {
+  const managedRef = useRef(false);
+
+  useEffect(() => {
+    const hasQwenSource = sources.some(
+      (source) =>
+        typeof source.baseUrl === "string" &&
+        source.baseUrl.startsWith(QWEN_BASE_URL),
+    );
+
+    if (hasQwenSource) {
+      managedRef.current = true;
+      if (showQwenHint) {
+        setShowQwenHint(false);
+      }
+      return;
+    }
+
+    if (managedRef.current) {
+      setShowQwenHint(SHOULD_SHOW_QWEN_HINT_DEFAULT);
+      managedRef.current = false;
+    }
+  }, [sources, setShowQwenHint, showQwenHint]);
+}

--- a/src/lib/qwen.ts
+++ b/src/lib/qwen.ts
@@ -1,0 +1,2 @@
+export const QWEN_BASE_URL = "https://api.earthsworth.org/v1";
+export const QWEN_TOKEN_URL = "https://api.earthsworth.org/console/token";


### PR DESCRIPTION
## Summary
- add the Qwen Max service tip UI (shared tooltip, button, advanced toggle) to both Settings and Init pages
- introduce a small hook to auto-hide the tip when a Qwen endpoint exists, plus a reusable tooltip component
- extend en/zh locale files with the new strings and normalize language defaults to prevent hydration issues