### PR TITLE
fixed some build error in #6

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./dist/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/pages/SettingsPage.tsx
+++ b/src/components/pages/SettingsPage.tsx
@@ -12,7 +12,6 @@ import {
   type LanguagePreference,
   type ThemePreference,
   type ShortcutAction,
-  SHOULD_SHOW_QWEN_HINT_DEFAULT,
 } from "@/store/settings-store";
 import { cn } from "@/lib/utils";
 import { useCallback, useEffect, useMemo, useState } from "react";

--- a/src/store/settings-store.ts
+++ b/src/store/settings-store.ts
@@ -116,9 +116,9 @@ export const useSettingsStore = create<SettingsState>()(
       }),
       version: 5,
       migrate: (persistedState, version) => {
-        const data =
+        const data: Partial<SettingsState> & Record<string, unknown> =
           persistedState && typeof persistedState === "object"
-            ? { ...persistedState }
+            ? { ...(persistedState as Record<string, unknown>) }
             : {};
 
         if (version < 3) {


### PR DESCRIPTION
## Summary
- drop the unused SHOULD_SHOW_QWEN_HINT_DEFAULT import from SettingsPage to silence the build warning
- type the settings-store migration state before mutating keybindings to satisfy TypeScript
